### PR TITLE
[feat] 자동 납부일 페이지, custom selectBox

### DIFF
--- a/src/stories/atoms/selectBox/index.js
+++ b/src/stories/atoms/selectBox/index.js
@@ -1,0 +1,52 @@
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import { useState } from "react";
+
+const SelectBox = ({ text, selectedOption, setSelectedOption }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const options = Array.from({ length: 28 }, (_, i) => `${i + 1}일`);
+
+  const handleToggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleOptionSelect = (item) => {
+    setSelectedOption(item);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-14">{text}</div>
+      <div className="relative">
+        <div
+          className="rounded-10 focus:outline-none bg-gray-input px-12 py-15 w-full text-14 cursor-pointer flex justify-between"
+          onClick={handleToggle}
+        >
+          <span
+            className={`{${selectedOption}? "text-black-900": "text-gray-placeholder"}`}
+          >
+            {selectedOption ? selectedOption : "옵션을 선택하세요"}
+          </span>
+          <KeyboardArrowDownIcon className="text-superSubColor" />
+        </div>
+
+        {isOpen && (
+          <div className="absolute top-full left-0 z-10 w-full rounded-12 border mt-1 bg-white p-3 gray-border">
+            {options.map((item, index) => (
+              <div
+                key={`${item}+${index}`}
+                className="px-10 py-10 cursor-pointer hover:bg-gray-200 bg-white text-15"
+                onClick={() => handleOptionSelect(item)}
+              >
+                {item}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SelectBox;

--- a/src/stories/atoms/selectBox/index.stories.jsx
+++ b/src/stories/atoms/selectBox/index.stories.jsx
@@ -1,0 +1,13 @@
+import store from "libs/store";
+
+import { Provider } from "react-redux";
+import SelectBox from ".";
+
+export default {
+  component: SelectBox,
+  title: "atoms/selectBox",
+  decorators: [(story) => <Provider store={store}>{story()}</Provider>],
+  tags: ["autodocs"],
+};
+
+export const Default = {};

--- a/src/stories/pages/loanPage/index.jsx
+++ b/src/stories/pages/loanPage/index.jsx
@@ -1,9 +1,13 @@
 import React, { useState } from "react";
 import Page1 from "./page1";
 import Page2 from "./page2";
+import Page3 from "./page3";
 
 const LoanPage = () => {
   const [page, setPage] = useState(1);
+  //repay
+  //BULLET - 만기일시상환
+  //EQUAL_INSTALLMENT - 원리금균등상환
   const mock = {
     prodCode: "",
     prodType: "",
@@ -14,8 +18,8 @@ const LoanPage = () => {
     prodMax: 100350000,
     joinMember: "",
     prodLimit: "",
-    prodRateMthd: 3.5,
-    prodRepay: "만기일시상환",
+    prodRateMthd: 0.035,
+    prodRepay: "EQUAL_INSTALLMENT",
     prodCaution: "",
     prodAcc: "",
     prodpromo: "",
@@ -30,7 +34,7 @@ const LoanPage = () => {
     <div>
       {page === 1 && <Page1 moveNextPage={moveNextPage} mock={mock} />}
       {page === 2 && <Page2 moveNextPage={moveNextPage} mock={mock} />}
-      {/* {page === 3 && <Page3 mock={mock} />} */}
+      {page === 3 && <Page3 mock={mock} />}
     </div>
   );
 };

--- a/src/stories/pages/loanPage/page3.jsx
+++ b/src/stories/pages/loanPage/page3.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import LongButton from "stories/atoms/longButton";
+import SelectBox from "stories/atoms/selectBox";
+import Title from "stories/atoms/title";
+import HeaderBar from "stories/molecules/headerBar";
+
+const Page3 = ({ moveNextPage, mock }) => {
+  const [selectedOption, setSelectedOption] = useState("");
+
+  return (
+    <div className="px-40 pt-30 w-full flex flex-col flex-1">
+      <HeaderBar text={"대출가입"} />
+      <Title text1={"자동 납부일을 선택해주세요"} />
+      <div className="mt-35">
+        <SelectBox
+          selectedOption={selectedOption}
+          setSelectedOption={setSelectedOption}
+        />
+      </div>
+      <div className="flex flex-col justify-center items-center fixed left-0 bottom-0 w-full px-40 mb-50">
+        <LongButton
+          text={"다음"}
+          active={!!selectedOption}
+          onClick={moveNextPage}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Page3;


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)
- [x] 화면 작업 (Style, CSS)

## 작업 내용
- 커스텀 셀렉트 박스 구현
- 자동 납부일 페이지에서 선택한 값 받기
- 자동 납부일 option은 28일까지로 구현
- closes #74 

## Before

## After

<img width="653" alt="스크린샷 2024-05-31 오후 2 01 44" src="https://github.com/BangCrush/BankAI-Frontend/assets/69382168/d46deab8-c923-4e12-8440-afb63403c048">

<img width="565" alt="스크린샷 2024-05-31 오후 2 00 29" src="https://github.com/BangCrush/BankAI-Frontend/assets/69382168/cca792a4-a9de-4bfe-b579-3b163daa2bda">

<img width="561" alt="스크린샷 2024-05-31 오후 2 01 05" src="https://github.com/BangCrush/BankAI-Frontend/assets/69382168/09cafec6-b4fd-42b3-a367-07df1cf4ba68">

<img width="563" alt="스크린샷 2024-05-31 오후 2 00 36" src="https://github.com/BangCrush/BankAI-Frontend/assets/69382168/7e319bec-a44e-4caa-8405-7f9106e9230a">


## 참고 사항, 첨부 자료 등
