### PR TITLE
[fix] 계좌 내역 조회 시 이자 태그 출력 type 반영 / 금융 상식 디테일 페이지 스크롤 0 적용

### DIFF
--- a/src/constants/accounts.js
+++ b/src/constants/accounts.js
@@ -1,5 +1,6 @@
 const historyTypeMapping = {
   TRANSFER: "이체",
   AUTO_TRANSFER: "자동이체",
+  PAY_INTEREST: "이자",
 };
 export { historyTypeMapping };

--- a/src/stories/molecules/accHistory/index.js
+++ b/src/stories/molecules/accHistory/index.js
@@ -4,6 +4,7 @@ const AccHistory = ({ data }) => {
   const date = new Date(data.hisDateTime);
   const month = date.getMonth() + 1;
   const day = date.getDate();
+  console.log(data.hisType);
 
   return (
     <div className="border-gray-800 border-solid border-b-1 pb-19 py-20 px-20">

--- a/src/stories/pages/InfoPage/bancassurancePage.jsx
+++ b/src/stories/pages/InfoPage/bancassurancePage.jsx
@@ -10,6 +10,7 @@ const BancassurancePage = () => {
     setTimeout(() => {
       setIsAnimated(true);
     }, 100);
+    document.scrollingElement.scrollTop = 0;
   }, []);
 
   return (

--- a/src/stories/pages/InfoPage/precautionPage.jsx
+++ b/src/stories/pages/InfoPage/precautionPage.jsx
@@ -10,6 +10,7 @@ const PrecautionPage = () => {
     setTimeout(() => {
       setIsAnimated(true);
     }, 100);
+    document.scrollingElement.scrollTop = 0;
   }, []);
 
   return (

--- a/src/stories/pages/accHistoryPage/index.jsx
+++ b/src/stories/pages/accHistoryPage/index.jsx
@@ -76,7 +76,7 @@ const AccHistoryPage = () => {
           ></BlueHeaderBar>
           <div className="w-full pt-6 pb-19 px-227 bg-sub-color text-center">
             <p className="text-14 mb-14 underline text-gray-semi">{accCode}</p>
-            <p className="text-26 font-extrabold mb-14">
+            <p className="text-26 font-extrabold mb-14 text-nowrap">
               {parseInt(accountBalance, 10).toLocaleString()}원
             </p>
             <MediumButton text={"이체하기"} onClick={handleTransfer} />


### PR DESCRIPTION
### PR Type

- [X] 기능 개발 (Feature)
- [X] 화면 작업 (Style, CSS)
- [X] 리팩토링 (no functional changes, no api changes)
## 작업 내용

- closes

## After
[계좌 내역 조회 시 이자 태그 출력 type 반영](https://github.com/BangCrush/BankAI-Frontend/commit/d5ebe8b24bf3fcd65a50cb950243319361eb89c9)
[금융 상식 디테일 페이지 스크롤 0 적용](https://github.com/BangCrush/BankAI-Frontend/commit/a5f932862a43956d3108e816db5b4ae737d2c0bb)

