### PR TITLE
[fix] 음성 입력 중에 AI 비활성화 시 페이지 비활성화 오류 해결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -125,7 +125,7 @@ function MainApp() {
           <Route path="/accHistory" element={<AccHistoryPage />}></Route>
         </Routes>
 
-        {isIncludeAIServicePage ? (
+      {isIncludeAIServicePage && autoPlay ? (
           <>
             <VideoComp
               isVideoPlaying={isVideoPlaying}
@@ -140,6 +140,7 @@ function MainApp() {
               setResult={setResult}
               options={options}
               type={type}
+              autoPlay={autoPlay}
             />
           </>
         ) : (

--- a/src/stories/organisms/voiceServiceComp/index.jsx
+++ b/src/stories/organisms/voiceServiceComp/index.jsx
@@ -7,7 +7,7 @@ import VoiceWave from "stories/atoms/voiceVisual";
 
 const speechsdk = require("microsoft-cognitiveservices-speech-sdk");
 
-const VoiceServiceComp = ({ setResult, options, type, isVideoPlaying }) => {
+const VoiceServiceComp = ({ setResult, options, type, isVideoPlaying, autoPlay }) => {
   const [displayText, setDisplayText] = useState();
   const [isRecording, setIsRecording] = useState(false);
   const [show, setShow] = useState(false);
@@ -17,6 +17,13 @@ const VoiceServiceComp = ({ setResult, options, type, isVideoPlaying }) => {
       sttFromMic();
     }
   }, [isVideoPlaying]);
+
+  useEffect(() => {
+    if (!autoPlay){
+      setShow(false);
+      setIsRecording(false);
+      setDisplayText(null);
+    }},[autoPlay]);
 
   async function sttFromMic() {
     const tokenObj = await getTokenOrRefresh();


### PR DESCRIPTION
### PR Type

- [X] 기능 개발 (Feature)
- [X] 리팩토링 (no functional changes, no api changes)

## 작업 내용
[[fix] 음성 입력 중에 AI 비활성화 시 페이지 비활성화 오류 해결](https://github.com/BangCrush/BankAI-Frontend/commit/da7b201bc9d88cd474000a2e0b8b21b8d96985e3)

AI 기능 토글 시 음성 입력중이었으면 해당 부분에 비정상 작동이 발생하여 페이지 동작이 멈추는 현상을 해결하고자
AI 기능 토글 값이 변경되면 useEffect가 실행되고, 토글 값이 false일 때는 음성 입력 받기를 종료하는 로직을 작성
